### PR TITLE
fix: ignore `EISDIR` errors when reading files

### DIFF
--- a/src/__tests__/resolveWorkspaceRoot.test.ts
+++ b/src/__tests__/resolveWorkspaceRoot.test.ts
@@ -154,6 +154,17 @@ describe('bun, npm, yarn', () => {
 
     expect(resolveWorkspaceRoot('/test/packages/awesome-pkg')).toBe(null);
   });
+
+  it('ignores folder named as package.json', () => {
+    vol.fromJSON({
+      '/test/packages/awesome-pkg/package.json': JSON.stringify({
+        name: 'awesome-pkg',
+      }),
+      '/test/package.json/test.txt': 'this creates the folder',
+    });
+
+    expect(resolveWorkspaceRoot('/test/packages/awesome-pkg')).toBe(null);
+  });
 });
 
 describe('pnpm', () => {
@@ -237,6 +248,17 @@ describe('pnpm', () => {
         name: 'awesome-pkg',
       }),
       '/test/pnpm-workspace.yaml': stringifyYaml({ packages: ['packages/*'] }),
+    });
+
+    expect(resolveWorkspaceRoot('/test/packages/awesome-pkg')).toBe(null);
+  });
+
+  it('ignores folder named as package.json', () => {
+    vol.fromJSON({
+      '/test/packages/awesome-pkg/package.json': JSON.stringify({
+        name: 'awesome-pkg',
+      }),
+      '/test/package.json/test.txt': 'this creates the folder',
     });
 
     expect(resolveWorkspaceRoot('/test/packages/awesome-pkg')).toBe(null);

--- a/src/__tests__/resolveWorkspaceRootAsync.test.ts
+++ b/src/__tests__/resolveWorkspaceRootAsync.test.ts
@@ -158,6 +158,17 @@ describe('bun, npm, yarn', () => {
 
     await expect(resolveWorkspaceRootAsync('/test/packages/awesome-pkg')).resolves.toBe(null);
   });
+
+  it('ignores folder named as package.json', async () => {
+    vol.fromJSON({
+      '/test/packages/awesome-pkg/package.json': JSON.stringify({
+        name: 'awesome-pkg',
+      }),
+      '/test/package.json/test.txt': 'this creates the folder',
+    });
+
+    await expect(resolveWorkspaceRootAsync('/test/packages/awesome-pkg')).resolves.toBe(null);
+  });
 });
 
 describe('pnpm', () => {
@@ -243,6 +254,17 @@ describe('pnpm', () => {
         name: 'awesome-pkg',
       }),
       '/test/pnpm-workspace.yaml': stringifyYaml({ packages: ['packages/*'] }),
+    });
+
+    await expect(resolveWorkspaceRootAsync('/test/packages/awesome-pkg')).resolves.toBe(null);
+  });
+
+  it('ignores folder named as package.json', async () => {
+    vol.fromJSON({
+      '/test/packages/awesome-pkg/package.json': JSON.stringify({
+        name: 'awesome-pkg',
+      }),
+      '/test/package.json/test.txt': 'this creates the folder',
     });
 
     await expect(resolveWorkspaceRootAsync('/test/packages/awesome-pkg')).resolves.toBe(null);

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -4,7 +4,7 @@ export function tryReadFile(file: string): string | null {
   try {
     return fs.readFileSync(file, { encoding: 'utf-8' });
   } catch (error: any) {
-    if (error.code === 'ENOENT') {
+    if (shouldIgnoreError(error)) {
       return null;
     }
 
@@ -14,10 +14,18 @@ export function tryReadFile(file: string): string | null {
 
 export function tryReadFileAsync(file: string): Promise<string | null> {
   return fs.promises.readFile(file, { encoding: 'utf-8' }).catch((error: any) => {
-    if ('code' in error && error.code === 'ENOENT') {
+    if (shouldIgnoreError(error)) {
       return null;
     }
 
     throw error;
   });
+}
+
+/**
+ * We are optimistically reading files, avoiding unnecessary file lookup checks.
+ * Some thrown errors are expected and should be ignored as "file not found".
+ */
+function shouldIgnoreError(error: any): error is Error {
+  return 'code' in error && (error.code === 'ENOENT' || error.code === 'EISDIR');
 }


### PR DESCRIPTION
### Linked issue
If somehow users created a `package.json` folder, we still want to return `null` and not error.
