### PR TITLE
fix: Ignore missing root `package.json` when `pnpm-workspace.yaml` matches

### DIFF
--- a/src/__tests__/resolveWorkspaceRoot.test.ts
+++ b/src/__tests__/resolveWorkspaceRoot.test.ts
@@ -221,6 +221,19 @@ describe('pnpm', () => {
     expect(getWorkspaceGlobs('/test')).toEqual(['packages/*']);
   });
 
+  it('detects root with missing package.json', () => {
+    vol.fromJSON({
+      '/test/packages/awesome-pkg/package.json': JSON.stringify({
+        name: 'awesome-pkg',
+      }),
+      '/test/pnpm-workspace.yaml': stringifyYaml({ packages: ['packages/*'] }),
+    });
+
+    expect(resolveWorkspaceRoot('/test/packages/awesome-pkg')).toBe('/test');
+    // Note: in this case, its still correct to actually return the workspace globs
+    expect(getWorkspaceGlobs('/test')).toEqual(['packages/*']);
+  });
+
   it('ignores mismatching workspace', () => {
     vol.fromJSON({
       '/test/packages/awesome-pkg/package.json': JSON.stringify({
@@ -258,19 +271,6 @@ describe('pnpm', () => {
 
     expect(resolveWorkspaceRoot('/test/packages/awesome-pkg')).toBe(null);
     expect(getWorkspaceGlobs('/test')).toEqual(null);
-  });
-
-  it('ignores missing workspace package.json', () => {
-    vol.fromJSON({
-      '/test/packages/awesome-pkg/package.json': JSON.stringify({
-        name: 'awesome-pkg',
-      }),
-      '/test/pnpm-workspace.yaml': stringifyYaml({ packages: ['packages/*'] }),
-    });
-
-    expect(resolveWorkspaceRoot('/test/packages/awesome-pkg')).toBe(null);
-    // Note: in this case, its still correct to actually return the workspace globs
-    expect(getWorkspaceGlobs('/test')).toEqual(['packages/*']);
   });
 
   it('ignores folder named as package.json', () => {

--- a/src/__tests__/resolveWorkspaceRootAsync.test.ts
+++ b/src/__tests__/resolveWorkspaceRootAsync.test.ts
@@ -227,6 +227,19 @@ describe('pnpm', () => {
     await expect(getWorkspaceGlobsAsync('/test')).resolves.toEqual(['packages/*']);
   });
 
+  it('detects root with missing package.json', async () => {
+    vol.fromJSON({
+      '/test/packages/awesome-pkg/package.json': JSON.stringify({
+        name: 'awesome-pkg',
+      }),
+      '/test/pnpm-workspace.yaml': stringifyYaml({ packages: ['packages/*'] }),
+    });
+
+    await expect(resolveWorkspaceRootAsync('/test/packages/awesome-pkg')).resolves.toBe('/test');
+    // Note: in this case, its still correct to actually return the workspace globs
+    await expect(getWorkspaceGlobsAsync('/test')).resolves.toEqual(['packages/*']);
+  });
+
   it('ignores mismatching workspace', async () => {
     vol.fromJSON({
       '/test/packages/awesome-pkg/package.json': JSON.stringify({
@@ -264,19 +277,6 @@ describe('pnpm', () => {
 
     await expect(resolveWorkspaceRootAsync('/test/packages/awesome-pkg')).resolves.toBe(null);
     await expect(getWorkspaceGlobsAsync('/test')).resolves.toBe(null);
-  });
-
-  it('ignores missing workspace package.json', async () => {
-    vol.fromJSON({
-      '/test/packages/awesome-pkg/package.json': JSON.stringify({
-        name: 'awesome-pkg',
-      }),
-      '/test/pnpm-workspace.yaml': stringifyYaml({ packages: ['packages/*'] }),
-    });
-
-    await expect(resolveWorkspaceRootAsync('/test/packages/awesome-pkg')).resolves.toBe(null);
-    // Note: in this case, its still correct to actually return the workspace globs
-    await expect(getWorkspaceGlobsAsync('/test')).resolves.toEqual(['packages/*']);
   });
 
   it('ignores folder named as package.json', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,18 +27,18 @@ export function resolveWorkspaceRoot(
   options: ResolveWorkspaceOptions = {}
 ): string | null {
   return searchParentDirs(startingDir, (currentDir, relativeDir) => {
-    if (options.packageWorkspaces !== false) {
-      const packageContent = tryReadFile(path.join(currentDir, 'package.json'));
-      const packageGlobs = packageContent && workspaceGlobsFromPackage(packageContent);
-      if (packageGlobs && pathMatchesWorkspaceGlobs(packageGlobs, relativeDir)) {
-        return currentDir;
-      }
-    }
-
     if (options.pnpmWorkspaces !== false) {
       const workspaceContent = tryReadFile(path.join(currentDir, 'pnpm-workspace.yaml'));
       const workspaceGlobs = workspaceContent && workspaceGlobsFromPnpm(workspaceContent);
       if (workspaceGlobs && pathMatchesWorkspaceGlobs(workspaceGlobs, relativeDir)) {
+        return currentDir;
+      }
+    }
+
+    if (options.packageWorkspaces !== false) {
+      const packageContent = tryReadFile(path.join(currentDir, 'package.json'));
+      const packageGlobs = packageContent && workspaceGlobsFromPackage(packageContent);
+      if (packageGlobs && pathMatchesWorkspaceGlobs(packageGlobs, relativeDir)) {
         return currentDir;
       }
     }
@@ -58,18 +58,18 @@ export function resolveWorkspaceRootAsync(
   options: ResolveWorkspaceOptions = {}
 ): Promise<string | null> {
   return searchParentDirsAsync(startingDir, async (currentDir, relativeDir) => {
-    if (options.packageWorkspaces !== false) {
-      const packageContent = await tryReadFileAsync(path.join(currentDir, 'package.json'));
-      const packageGlobs = packageContent && workspaceGlobsFromPackage(packageContent);
-      if (packageGlobs && pathMatchesWorkspaceGlobs(packageGlobs, relativeDir)) {
-        return currentDir;
-      }
-    }
-
     if (options.pnpmWorkspaces !== false) {
       const workspaceContent = await tryReadFileAsync(path.join(currentDir, 'pnpm-workspace.yaml'));
       const workspaceGlobs = workspaceContent && workspaceGlobsFromPnpm(workspaceContent);
       if (workspaceGlobs && pathMatchesWorkspaceGlobs(workspaceGlobs, relativeDir)) {
+        return currentDir;
+      }
+    }
+
+    if (options.packageWorkspaces !== false) {
+      const packageContent = await tryReadFileAsync(path.join(currentDir, 'package.json'));
+      const packageGlobs = packageContent && workspaceGlobsFromPackage(packageContent);
+      if (packageGlobs && pathMatchesWorkspaceGlobs(packageGlobs, relativeDir)) {
         return currentDir;
       }
     }
@@ -87,19 +87,19 @@ export function getWorkspaceGlobs(
   rootDir = process.cwd(),
   options: ResolveWorkspaceOptions = {}
 ): string[] | null {
-  if (options.packageWorkspaces !== false) {
-    const packageContent = tryReadFile(path.join(rootDir, 'package.json'));
-    const packageGlobs = packageContent && workspaceGlobsFromPackage(packageContent);
-    if (packageGlobs) {
-      return packageGlobs;
-    }
-  }
-
   if (options.pnpmWorkspaces !== false) {
     const workspaceContent = tryReadFile(path.join(rootDir, 'pnpm-workspace.yaml'));
     const workspaceGlobs = workspaceContent && workspaceGlobsFromPnpm(workspaceContent);
     if (workspaceGlobs) {
       return workspaceGlobs;
+    }
+  }
+
+  if (options.packageWorkspaces !== false) {
+    const packageContent = tryReadFile(path.join(rootDir, 'package.json'));
+    const packageGlobs = packageContent && workspaceGlobsFromPackage(packageContent);
+    if (packageGlobs) {
+      return packageGlobs;
     }
   }
 
@@ -117,19 +117,19 @@ export async function getWorkspaceGlobsAsync(
   rootDir = process.cwd(),
   options: ResolveWorkspaceOptions = {}
 ): Promise<string[] | null> {
-  if (options.packageWorkspaces !== false) {
-    const packageContent = await tryReadFileAsync(path.join(rootDir, 'package.json'));
-    const packageGlobs = packageContent && workspaceGlobsFromPackage(packageContent);
-    if (packageGlobs) {
-      return packageGlobs;
-    }
-  }
-
   if (options.pnpmWorkspaces !== false) {
     const workspaceContent = await tryReadFileAsync(path.join(rootDir, 'pnpm-workspace.yaml'));
     const workspaceGlobs = workspaceContent && workspaceGlobsFromPnpm(workspaceContent);
     if (workspaceGlobs) {
       return workspaceGlobs;
+    }
+  }
+
+  if (options.packageWorkspaces !== false) {
+    const packageContent = await tryReadFileAsync(path.join(rootDir, 'package.json'));
+    const packageGlobs = packageContent && workspaceGlobsFromPackage(packageContent);
+    if (packageGlobs) {
+      return packageGlobs;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,17 +27,15 @@ export function resolveWorkspaceRoot(
   options: ResolveWorkspaceOptions = {}
 ): string | null {
   return searchParentDirs(startingDir, (currentDir, relativeDir) => {
-    let packageContent: string | null = null;
-
     if (options.packageWorkspaces !== false) {
-      packageContent = tryReadFile(path.join(currentDir, 'package.json'));
+      const packageContent = tryReadFile(path.join(currentDir, 'package.json'));
       const packageGlobs = packageContent && workspaceGlobsFromPackage(packageContent);
       if (packageGlobs && pathMatchesWorkspaceGlobs(packageGlobs, relativeDir)) {
         return currentDir;
       }
     }
 
-    if (options.pnpmWorkspaces !== false && packageContent) {
+    if (options.pnpmWorkspaces !== false) {
       const workspaceContent = tryReadFile(path.join(currentDir, 'pnpm-workspace.yaml'));
       const workspaceGlobs = workspaceContent && workspaceGlobsFromPnpm(workspaceContent);
       if (workspaceGlobs && pathMatchesWorkspaceGlobs(workspaceGlobs, relativeDir)) {
@@ -60,17 +58,15 @@ export function resolveWorkspaceRootAsync(
   options: ResolveWorkspaceOptions = {}
 ): Promise<string | null> {
   return searchParentDirsAsync(startingDir, async (currentDir, relativeDir) => {
-    let packageContent: string | null = null;
-
     if (options.packageWorkspaces !== false) {
-      packageContent = await tryReadFileAsync(path.join(currentDir, 'package.json'));
+      const packageContent = await tryReadFileAsync(path.join(currentDir, 'package.json'));
       const packageGlobs = packageContent && workspaceGlobsFromPackage(packageContent);
       if (packageGlobs && pathMatchesWorkspaceGlobs(packageGlobs, relativeDir)) {
         return currentDir;
       }
     }
 
-    if (options.pnpmWorkspaces !== false && packageContent) {
+    if (options.pnpmWorkspaces !== false) {
       const workspaceContent = await tryReadFileAsync(path.join(currentDir, 'pnpm-workspace.yaml'));
       const workspaceGlobs = workspaceContent && workspaceGlobsFromPnpm(workspaceContent);
       if (workspaceGlobs && pathMatchesWorkspaceGlobs(workspaceGlobs, relativeDir)) {


### PR DESCRIPTION
## Summary

Resolves https://github.com/expo/expo/issues/41806

It's unclear when this changed, but pnpm now accepts a monorepo setup without a root `package.json` and will happily install a monorepo without a `package.json` in the root. This is likely a limitation they lifted.

This means that we shouldn't lock `pnpm-workspace.yaml` matching behind `package.json` and instead go ahead and match it, since `pnpm install` will match it.

This should be safe to release as a patch since it only lifts a prerequisite condition.

## Set of changes

- Ignore missing `package.json` when matching `pnpm-workspace.yaml`
- Check for `pnpm-workspace.yaml` before checking `package.json` (as pnpm would be doing this)

The latter could cause changes in behaviour for projects with mixed setups, but likely shouldn't otherwise cause problems.